### PR TITLE
Bugfix/2334 20250523 rt

### DIFF
--- a/internal/commands/commit.go
+++ b/internal/commands/commit.go
@@ -73,6 +73,18 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Get current branch name
+	branchName, err := git.GetCurrentBranch()
+	if err != nil {
+		ui.ShowWarning("Could not get current branch name, proceeding without it.")
+	}
+
+	// Extract commit details from branch name
+	extractedType, ticketNumber := git.ExtractCommitDetails(branchName)
+	if extractedType != "" {
+		commitType = extractedType
+	}
+
 	// Get staged changes
 	diff, err := git.GetStagedDiff()
 	if err != nil {
@@ -153,6 +165,10 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		} else {
 			return fmt.Errorf("failed to generate commit message: %w", err)
 		}
+	}
+
+	if ticketNumber != "" {
+		commitMsg.Subject = fmt.Sprintf("%s-%s", ticketNumber, commitMsg.Subject)
 	}
 
 	// Display the generated commit message

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -1,0 +1,47 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// GetCurrentBranch returns the current git branch name
+func GetCurrentBranch() (string, error) {
+	cmd := exec.Command("git", "branch", "--show-current")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("git branch failed: %w, stderr: %s", err, stderr.String())
+	}
+
+	return strings.TrimSpace(out.String()), nil
+}
+
+// ExtractCommitDetails extracts the commit type and ticket number from the branch name.
+func ExtractCommitDetails(branchName string) (string, string) {
+	branchName = strings.ToLower(branchName)
+	var commitType, ticketNumber string
+
+	// Extract ticket number
+	re := regexp.MustCompile(`(\d{4,5})`)
+	matches := re.FindStringSubmatch(branchName)
+	if len(matches) > 1 {
+		ticketNumber = matches[1]
+	}
+
+	// Determine commit type
+	if strings.Contains(branchName, "fix") || strings.Contains(branchName, "bugfix") {
+		commitType = "fix"
+	} else if strings.Contains(branchName, "feature") || strings.Contains(branchName, "feat") {
+		commitType = "feat"
+	}
+
+	return commitType, ticketNumber
+}

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -29,6 +29,10 @@ func ExtractCommitDetails(branchName string) (string, string) {
 	branchName = strings.ToLower(branchName)
 	var commitType, ticketNumber string
 
+	// Remove date patterns (YYYYMMDD) from branch name
+	dateRegex := regexp.MustCompile(`\d{8}`)
+	branchName = dateRegex.ReplaceAllString(branchName, "")
+
 	// Extract ticket number
 	re := regexp.MustCompile(`(\d{4,5})`)
 	matches := re.FindStringSubmatch(branchName)

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -18,6 +18,7 @@ func TestExtractCommitDetails(t *testing.T) {
 		{"release/v1.0", "", ""},
 		{"no-ticket-feat", "feat", ""},
 		{"12345-fix-something", "fix", "12345"},
+		{"feature/1234-20250620-new-login", "feat", "1234"},
 	}
 
 	for _, tt := range tests {

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -1,0 +1,34 @@
+package git
+
+import (
+	"testing"
+)
+
+func TestExtractCommitDetails(t *testing.T) {
+	tests := []struct {
+		branchName   string
+		expectedType string
+		expectedTicket string
+	}{
+		{"feature/1234-new-login", "feat", "1234"},
+		{"fix/5678-fix-bug", "fix", "5678"},
+		{"bugfix/8765-another-bug", "fix", "8765"},
+		{"feat/4321-add-feature", "feat", "4321"},
+		{"hotfix/9999-critical-issue", "fix", "9999"},
+		{"release/v1.0", "", ""},
+		{"no-ticket-feat", "feat", ""},
+		{"12345-fix-something", "fix", "12345"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.branchName, func(t *testing.T) {
+			commitType, ticketNumber := ExtractCommitDetails(tt.branchName)
+			if commitType != tt.expectedType {
+				t.Errorf("expected type %q, got %q", tt.expectedType, commitType)
+			}
+			if ticketNumber != tt.expectedTicket {
+				t.Errorf("expected ticket %q, got %q", tt.expectedTicket, ticketNumber)
+			}
+		})
+	}
+}

--- a/internal/git/log.go
+++ b/internal/git/log.go
@@ -56,20 +56,7 @@ func GetCommits(opts CommitOptions) ([]Commit, error) {
 }
 
 // GetCurrentBranch returns the current git branch name
-func GetCurrentBranch() (string, error) {
-	cmd := exec.Command("git", "branch", "--show-current")
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	
-	err := cmd.Run()
-	if err != nil {
-		return "", fmt.Errorf("git branch failed: %w, stderr: %s", err, stderr.String())
-	}
-	
-	return strings.TrimSpace(out.String()), nil
-}
+
 
 func parseCommits(output string) []Commit {
 	lines := strings.Split(strings.TrimSpace(output), "\n")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commit messages now automatically extract commit type and ticket number from the current branch name, enhancing message consistency and traceability.
  * If a ticket number is detected, it is prefixed to the commit message subject.

* **Bug Fixes**
  * Added a warning if the current branch name cannot be retrieved, but the commit process continues.

* **Tests**
  * Introduced tests to verify extraction of commit type and ticket number from various branch naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->